### PR TITLE
Reflect and set route in Header and Catalog

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -12,6 +12,7 @@
         "ThomasWeiser/elmfire-extra": "1.0.3 <= v < 2.0.0",
         "elm-community/elm-history": "1.0.1 <= v < 2.0.0",
         "elm-lang/core": "3.0.0 <= v < 4.0.0",
+        "etaque/elm-route-parser": "2.2.0 <= v < 3.0.0",
         "etaque/elm-simple-form": "1.0.2 <= v < 2.0.0",
         "evancz/elm-effects": "2.0.1 <= v < 3.0.0",
         "evancz/elm-html": "4.0.2 <= v < 5.0.0",

--- a/src/Components/Catalog.elm
+++ b/src/Components/Catalog.elm
@@ -1,12 +1,13 @@
-module Components.Catalog (Model, init, Action, update, view, setIssues) where
+module Components.Catalog (Model, init, Action, update, Context, view, setIssues) where
 
 import Signal exposing (Address, forwardTo)
 import Html as H exposing (Html)
 import Html.Attributes as HA
 import Html.Events as HE
-import Store.Issues as Issues exposing (Issue)
 
 import CommonTypes exposing (Slug)
+import Store.Issues as Issues exposing (Issue)
+import Route exposing (Route)
 
 
 type alias Model =
@@ -63,13 +64,19 @@ clip model =
     }
 
 
-view : Address Action -> Model -> Html
-view address model =
+type alias Context =
+  { route : Route
+  , setRouteAddress : Address Route
+  }
+
+
+view : Address Action -> Context -> Model -> Html
+view address context model =
   H.div
     [ HA.class "catalog" ]
     [ H.ul
         []
-        ( List.map (viewIssue address) model.visible )
+        ( List.map (viewIssue address context) model.visible )
     , H.button
         [ HA.disabled (model.position <= 0)
         , HE.onClick address <| Scroll (0 - model.size)
@@ -82,9 +89,20 @@ view address model =
     ]
 
 
-viewIssue : Address Action -> (Slug, Issue) -> Html
-viewIssue address (slug, issue) =
-  H.li
-    [ HA.class "item" ]
-    [ -- TODO: Also show small images
-      H.text <| slug ]
+viewIssue : Address Action -> Context -> (Slug, Issue) -> Html
+viewIssue address context (slug, issue) =
+  let
+    isCurrentRoute = context.route == Route.Issue slug
+  in
+    H.li
+      [ HA.classList
+          [ ("item", True)
+          , ("selected", isCurrentRoute)
+          ]
+      ]
+      [ H.button
+          [ HA.disabled isCurrentRoute
+          , HE.onClick context.setRouteAddress <| Route.Issue slug
+          ]
+          [ H.text <| slug ]
+      ]

--- a/src/Components/Header.elm
+++ b/src/Components/Header.elm
@@ -1,10 +1,12 @@
-module Components.Header (Model, init, Action, update, view, setShop) where
+module Components.Header (Model, init, Action, update, Context, view, setShop) where
 
 import Signal exposing (Address, forwardTo)
 import Html as H exposing (Html)
 import Html.Attributes as HA
--- import Html.Events as HE
+import Html.Events as HE
+
 import Store.Shop as Shop
+import Route exposing (Route)
 
 
 type alias Model =
@@ -25,11 +27,28 @@ update action model =
   model
 
 
-view : Address Action -> Model -> Html
-view address model =
+type alias Context =
+  { route : Route
+  , setRouteAddress : Address Route
+  }
+
+
+view : Address Action -> Context -> Model -> Html
+view address context model =
   H.div
     [ HA.class "header" ]
-    [ H.text model.shopName ]
+    [ H.div
+        [ HA.class "shop-name" ]
+        [ H.text model.shopName ]
+    , H.div
+        [ HA.class "menu" ]
+        [ H.button
+            [ HA.disabled (context.route == Route.All)
+            , HE.onClick context.setRouteAddress <| Route.All
+            ]
+            [ H.text "All issues" ]
+        ]
+    ]
 
 
 -- TODO: Possibly simpler:

--- a/src/Components/Page.elm
+++ b/src/Components/Page.elm
@@ -1,8 +1,15 @@
-module Components.Page (Model, init, Action, update, view, setShop, setIssues) where
+module Components.Page
+  ( Model, init, Action, update, view
+  , setShop, setIssues, setRoute
+  ) where
 
 import Signal exposing (Mailbox, Address, mailbox, message, forwardTo)
+import Task exposing (Task, andThen)
 import Effects exposing (Effects, Never)
+import History
 import Html as H exposing (Html)
+
+import Route exposing (Route)
 import Store.Shop as Shop
 import Store.Issues as Issues
 import Components.Header as Header
@@ -13,14 +20,16 @@ import Components.Catalog as Catalog
 
 
 type alias Model =
-  { header : Header.Model
+  { route : Route
+  , header : Header.Model
   , catalog : Catalog.Model
   }
 
 
 init : ( Model, Effects Action )
 init =
-  ( { header = Header.init
+  ( { route = Route.Home
+    , header = Header.init
     , catalog = Catalog.init 6
     }
   , Effects.none
@@ -28,13 +37,18 @@ init =
 
 
 type Action
-  = HeaderAction Header.Action
+  = NoOp
+  | HeaderAction Header.Action
   | CatalogAction Catalog.Action
+  | SetRoute Route
 
 
 update : Action -> Model -> ( Model, Effects Action )
 update action model =
   case action of
+    NoOp ->
+      ( model, Effects.none )
+
     HeaderAction headerAction ->
       ( { model | header = Header.update headerAction model.header }
       , Effects.none
@@ -45,18 +59,33 @@ update action model =
       , Effects.none
       )
 
+    SetRoute route ->
+      ( model
+      , History.setPath (Route.path route)
+          |> Task.map (always NoOp)
+          |> Effects.task
+      )
+
 
 view : Address Action -> Model -> Html
 view address model =
-  H.div
-    []
-    [ Header.view
-        (forwardTo address HeaderAction)
-        model.header
-    , Catalog.view
-        (forwardTo address CatalogAction)
-        model.catalog
-    ]
+  let
+    context =
+      { route = model.route
+      , setRouteAddress = forwardTo address SetRoute
+      }
+  in
+    H.div
+      []
+      [ Header.view
+          (forwardTo address HeaderAction)
+          context
+          model.header
+      , Catalog.view
+          (forwardTo address CatalogAction)
+          context
+          model.catalog
+      ]
 
 -- TODO: Possibly simpler:
 --   Don't include shopName in local model. Give it as a context to view function instead.
@@ -67,3 +96,7 @@ setShop shop model =
 setIssues : Issues.Model -> Model -> Model
 setIssues issues model =
   { model | catalog = Catalog.setIssues issues model.catalog }
+
+setRoute : Route -> Model -> Model
+setRoute route model =
+  { model | route = route }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -8,6 +8,7 @@ import Effects exposing (Effects, Never)
 import History
 import ElmFire
 
+import Route
 import Store.Shop as Shop
 import Store.Issues as Issues
 import Components.Page as Page
@@ -19,7 +20,6 @@ import Components.Page as Page
 firebaseRoot : ElmFire.Location
 firebaseRoot =
   ElmFire.fromUrl "https://plentifulshop-demo.firebaseio.com/"
-
 
 
 --------------------------------------------------------------------------------
@@ -58,7 +58,6 @@ port runEffects =
 main : Signal Html
 main =
   app.html
-
 
 
 --------------------------------------------------------------------------------
@@ -115,11 +114,15 @@ update action model =
       ( model, Effects.none )
 
     PathChange path ->
-      -- TODO: To be implemented. Just loggin for now
-      always
-        ( model, Effects.none )
-        ( Debug.log "PathChange" path )
-
+      let
+        route =
+          Maybe.withDefault
+            Route.Home
+            (Route.match path)
+      in
+        ( { model | page = Page.setRoute route model.page }
+        , Effects.none
+        )
 
     ShopAction shopAction ->
       let

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -1,0 +1,29 @@
+module Route (Route(..), match, path) where
+
+import RouteParser exposing (..)
+
+--------------------------------------------------------------------------------
+
+type Route
+  = Home
+  | All
+  | Issue String
+
+--------------------------------------------------------------------------------
+
+matchers : List (Matcher Route)
+matchers =
+  [ static Home "/"
+  , static All "/all"
+  , dyn1 Issue "/" string ""
+  ]
+
+match : String -> Maybe Route
+match = RouteParser.match matchers
+
+path : Route -> String
+path r =
+  case r of
+    Home -> "/"
+    All -> "/all"
+    Issue slug -> "/" ++ slug

--- a/src/Store/Issues.elm
+++ b/src/Store/Issues.elm
@@ -47,7 +47,7 @@ init address location =
   , ElmFire.Dict.getDict
       (syncConfig location)
     |> Task.toResult
-    |> Task.map (QueryResult)
+    |> Task.map QueryResult
     |> Effects.task
   )
 


### PR DESCRIPTION
- Use a route parsing package
    - Use `etaque/elm-route-parser`
    - First tried `Bogdanp/elm-route`, but [stumbled](https://groups.google.com/forum/#!topic/elm-discuss/3YfvuKFUYNw) across a [compiler](https://github.com/elm-lang/elm-compiler/issues/1305) [bug](https://github.com/elm-lang/elm-compiler/issues/1096)
- New module `Route.elm`  
    Defines the shop's routes.
- `Page.elm`  
    Models current route. Provides action for changing the route.
- `Header.elm`  
    Menu entry "All issues"
- `Catalog.elm`  
    Reflect route (mark current issue, click on an issue to make it the current one)
