### PR TITLE
Sign-in/out, read purchases, show paid content

### DIFF
--- a/docs/fb-rules.json
+++ b/docs/fb-rules.json
@@ -1,0 +1,23 @@
+{
+  "rules": {
+    "shop": {
+        ".read": true
+    },
+    "issues": {
+        ".read": true
+    },
+    "customers": {
+      "$user": {
+        ".read":  "$user == auth.uid",
+        ".write": "$user == auth.uid"
+      }
+    },
+    "content": {
+      "$slug": {
+        "$key": {
+          ".read":  "root.child('customers').child(auth.uid).child('purchases').child($slug).val() == $key"
+        }
+      }
+    }
+  }
+}

--- a/docs/firebase.md
+++ b/docs/firebase.md
@@ -11,7 +11,6 @@ author: Thomas Weiser <elmdev@thomasweiser.de>
     - ...
 - customers
     - _uid_
-        - displayName: _String_
         - email: _String_
         - paymentData
             - id: _String_
@@ -42,6 +41,8 @@ author: Thomas Weiser <elmdev@thomasweiser.de>
 
 ## Permissions
 
+See [`fb-rules.json`](fb-rules.json)
+
 - `/shop`  
   readable to anyone
 - `/customers/$uid`  
@@ -49,7 +50,7 @@ author: Thomas Weiser <elmdev@thomasweiser.de>
 - `/issues`  
   readable to anyone
 - `/content/$slug/$key`  
-  readable if `$key == /customers/$uid/purchases/$slug/$key`
+  readable if `$key == /customers/$uid/purchases/$slug`
 - `/purchases/$uid`  
   writable for user `$uid`
 

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "clean": "rm -rf node_modules;rm -rf elm-stuff"
   },
   "dependencies": {
+    "css-loader": "^0.23.1",
     "elm-webpack-loader": "^1.1.1",
     "file-loader": "^0.8.5",
+    "style-loader": "^0.13.0",
     "webpack": "^1.12.0",
     "webpack-dev-server": "^1.14.0"
   }

--- a/src/CommonTypes.elm
+++ b/src/CommonTypes.elm
@@ -1,4 +1,6 @@
-module CommonTypes (Slug) where
+module CommonTypes (..) where
 
 
 type alias Slug = String
+type alias UId = String
+type alias IssueKey = String

--- a/src/Components/Catalog.elm
+++ b/src/Components/Catalog.elm
@@ -1,5 +1,5 @@
 module Components.Catalog
-  ( Model, init, Action, update, Context, view
+  ( Model, init, Action, update, view
   , setSize, setIssues
   ) where
 
@@ -10,6 +10,7 @@ import Html.Events as HE
 
 import CommonTypes exposing (Slug)
 import Store.Issues as Issues exposing (Issue)
+import Store.Customer as Customer
 import Route exposing (Route)
 
 
@@ -73,13 +74,15 @@ adaptVisible model =
     }
 
 
-type alias Context =
-  { route : Route
-  , setRouteAddress : Address Route
+type alias Context a =
+  { a
+  | setRouteAddress : Address Route
+  , route : Route
+  , customer : Maybe Customer.Model
   }
 
 
-view : Address Action -> Context -> Model -> Html
+view : Address Action -> Context a -> Model -> Html
 view address context model =
   H.div
     [ HA.class "catalog" ]
@@ -98,7 +101,7 @@ view address context model =
     ]
 
 
-viewIssue : Address Action -> Context -> (Slug, Issue) -> Html
+viewIssue : Address Action -> Context a -> (Slug, Issue) -> Html
 viewIssue address context (slug, issue) =
   let
     isCurrentRoute = context.route == Route.Issue slug

--- a/src/Components/Checkout.elm
+++ b/src/Components/Checkout.elm
@@ -1,0 +1,145 @@
+module Components.Checkout (Model, init, Action, update, view) where
+
+import Signal exposing (Address, forwardTo)
+import Task exposing (Task)
+import Effects exposing (Effects, Never)
+import Json.Encode as JE
+import Html as H exposing (Html)
+import Html.Attributes as HA
+import Html.Events as HE
+import Html.Lazy as HL
+
+import ElmFire
+import ElmFire.Auth
+
+import Form exposing (Form)
+import Form.Validate exposing (Validation, (:=))
+import Form.Field exposing (Field)
+import Form.Input
+
+import Config
+import CommonTypes exposing (Slug)
+import Store.Customer as Customer
+
+
+type alias Model =
+  { signInForm : Form () SignInData
+  }
+
+
+type alias SignInData =
+  { email : String
+  , password : String
+  }
+
+validateSignIn : Validation () SignInData
+validateSignIn =
+  Form.Validate.form2 SignInData
+    ("email" := Form.Validate.email)
+    ("password" := Form.Validate.string)
+
+
+init : Model
+init =
+  { signInForm =
+      Form.initial
+        [ ("email", Form.Field.text "")
+        , ("password", Form.Field.text "")
+        ]
+        validateSignIn
+      |> Form.update Form.validate
+  }
+
+
+type Action
+  = SignInFormAction Form.Action
+  | Submit
+  | AuthResult (Result ElmFire.Error ElmFire.Auth.Authentication)
+
+
+type alias Context =
+  { customer : Maybe Customer.Model
+  }
+
+
+update : Context -> Action -> Model -> ( Model, Effects Action )
+update context action model =
+  case action of
+    SignInFormAction formAction ->
+      ( { model | signInForm = Form.update formAction model.signInForm }
+      , Effects.none
+      )
+    Submit ->
+      let
+        authEffects =
+          case Form.getOutput model.signInForm of
+            Just { email, password } ->
+              ElmFire.Auth.authenticate
+                (ElmFire.fromUrl Config.firebaseUrl)
+                [ElmFire.Auth.rememberDefault]
+                (ElmFire.Auth.withPassword email password)
+              |> Task.toResult
+              |> Task.map AuthResult
+              |> Effects.task
+            Nothing -> -- Form invalid. Should not be reachable.
+              Effects.none
+      in
+        ( model, authEffects )
+    AuthResult authResult ->
+      -- TODO: Display possible authentication error
+      always
+      ( model, Effects.none )
+      <| Debug.log "authResult" authResult
+
+
+view : Address Action -> Model -> Html
+view address model =
+  let
+    form = model.signInForm
+    formAddress = forwardTo address SignInFormAction
+    emailState = Form.getFieldAsString "email" form
+    passwordState = Form.getFieldAsString "password" form
+    errorFor field =
+      case field.liveError of
+        Just error ->
+          H.span [ HA.class "invalid" ] [ H.text (toString error) ]
+        Nothing ->
+          H.text ""
+    valid = Form.getErrors form |> List.isEmpty
+  in
+  H.div
+    [ HA.class "checkout" ]
+    [ H.div
+        [ HA.class "login" ]
+        [ H.form
+            [ HA.name "login" -- TODO: necessary?
+            ]
+            [ Form.Input.textInput
+                emailState
+                formAddress
+                [ HA.class "email"
+                , HA.placeholder "email"
+                ]
+            , errorFor emailState
+            , Form.Input.textInput
+                passwordState
+                formAddress
+                [ HA.class "password"
+                , HA.placeholder "password"
+                , HA.type' "password"
+                ]
+            , errorFor passwordState
+            , H.button
+                [ HA.class "sign-in"
+                , HA.type' "button"
+                , HA.disabled (not valid)
+                -- TODO: Dispatch Form.submit instead?
+                -- Cf. https://github.com/etaque/elm-simple-form/blob/b2ab56b8ab0224ab39ef5b83517b1e2b349b2c8d/example/src/View.elm#L57
+                , HE.onClick address Submit
+                ]
+                [ H.text "Sign-in" ]
+            ]
+        ]
+    ]
+
+

--- a/src/Components/Header.elm
+++ b/src/Components/Header.elm
@@ -6,6 +6,7 @@ import Html.Attributes as HA
 import Html.Events as HE
 
 import Store.Shop as Shop
+import Store.Customer as Customer
 import Route exposing (Route)
 
 
@@ -27,26 +28,48 @@ update action model =
   model
 
 
-type alias Context =
-  { route : Route
-  , setRouteAddress : Address Route
+type alias Context a =
+  { a
+  | setRouteAddress : Address Route
+  , signOutAddress : Address ()
+  , route : Route
+  , customer : Maybe Customer.Model
   }
 
 
-view : Address Action -> Context -> Model -> Html
+view : Address Action -> Context a -> Model -> Html
 view address context model =
   H.div
     [ HA.class "header" ]
     [ H.div
         [ HA.class "shop-name" ]
         [ H.text model.shopName ]
+    , case context.customer of
+        Just customer ->
+          H.div
+            [ HA.class "email" ]
+            [ H.text customer.email ]
+        Nothing ->
+          H.text ""
     , H.div
         [ HA.class "menu" ]
         [ H.button
             [ HA.disabled (context.route == Route.All)
-            , HE.onClick context.setRouteAddress <| Route.All
+            , HE.onClick context.setRouteAddress Route.All
             ]
             [ H.text "All issues" ]
+        , case context.customer of
+            Just customer ->
+              H.button
+                [ HE.onClick context.signOutAddress ()
+                ]
+                [ H.text "Sign-out" ]
+            Nothing ->
+              H.button
+                [ -- TODO: Scroll down to sign-in-form
+                  -- HE.onClick context.setRouteAddress Route.All
+                ]
+                [ H.text "Sign-in" ]
         ]
     ]
 

--- a/src/Components/Stage.elm
+++ b/src/Components/Stage.elm
@@ -1,56 +1,141 @@
-module Components.Stage (Model, init, Action, update, Context, view) where
+module Components.Stage
+  ( Model, init, Action, update, view
+  , customerChanged
+  ) where
 
 import Signal exposing (Address, forwardTo)
+import Task exposing (Task, andThen)
+import Effects exposing (Effects, Never)
 import Json.Encode as JE
+import Json.Decode as JD exposing ((:=))
 import Html as H exposing (Html)
 import Html.Attributes as HA
 import Html.Events as HE
 import Html.Lazy as HL
+import ElmFire
 
-import CommonTypes exposing (Slug)
+import Config
+import CommonTypes exposing (..)
 import Store.Issues as Issues exposing (Issue)
+import Store.Customer as Customer
 import Route exposing (Route)
+import Components.Checkout as Checkout
 
 
 type alias Model =
   { slug : Slug
   , issue : Issue
+  , content : Maybe String
+  , checkout : Maybe Checkout.Model
   }
 
 
-init : Slug -> Issue -> Model
-init slug issue =
-  { slug = slug
-  , issue = issue
-  }
+init : Slug -> Issue -> Maybe Customer.Model -> ( Model, Effects Action )
+init slug issue maybeCustomer =
+  customerChanged
+    maybeCustomer
+    { slug = slug
+    , issue = issue
+    , content = Nothing
+    , checkout = Just Checkout.init
+    }
 
 
-type Action =
-  Dummy
-
-
-update : Action -> Model -> Model
-update action model =
-  case action of
-    Dummy ->
-      model
+type Action
+  = CheckoutAction Checkout.Action
+  | QueryContentResult (Result ElmFire.Error ElmFire.Snapshot)
 
 
 type alias Context =
-  { -- dummy : ()
+  { customer : Maybe Customer.Model
   }
 
-view : Address Action -> Context -> Model -> Html
-view =
-  HL.lazy3 viewThunk
 
-viewThunk : Address Action -> Context -> Model -> Html
-viewThunk address context { slug, issue } =
+decoderContentBody : JD.Decoder String
+decoderContentBody =
+  JD.object1 -- TODO Simpler?
+    identity
+    ("body" := JD.string)
+
+
+update : Context -> Action -> Model -> ( Model, Effects Action )
+update context action model =
+  case action of
+    CheckoutAction checkoutAction ->
+      case model.checkout of
+        Just checkout ->
+          let
+            ( checkoutModel, checkoutEffects ) =
+              Checkout.update context checkoutAction checkout
+          in
+          ( { model | checkout = Just checkoutModel }
+          , Effects.map CheckoutAction checkoutEffects
+          )
+        Nothing ->
+          ( model, Effects.none )
+
+    QueryContentResult (Err error) ->
+      always ( model, Effects.none )
+        <| Debug.log "Firebase: content query error" error
+
+    QueryContentResult (Ok snapshot) ->
+      case JD.decodeValue decoderContentBody snapshot.value of
+        Err error ->
+          always ( model, Effects.none ) <|
+            Debug.log "Firebase: content decoding error" error
+        Ok htmlBody ->
+          ( { model | content = Just htmlBody }
+          , Effects.none
+          )
+
+
+customerChanged : Maybe Customer.Model -> Model -> ( Model, Effects Action )
+customerChanged maybeCustomer model =
+  case maybeCustomer of
+    Just customer ->
+      case Customer.getIssueKey model.slug customer of
+        Just issueKey ->
+          case model.content of
+            Just content ->
+              ( model, Effects.none )
+            Nothing ->
+              ( { model | content = Just "<div>(fetching content)</div>" }
+              , fetchContent model.slug issueKey
+              )
+        Nothing ->
+          ( { model | content = Nothing }
+          , Effects.none
+          )
+    Nothing ->
+      ( { model | content = Nothing }
+      , Effects.none
+      )
+
+fetchContent : Slug -> IssueKey -> Effects Action
+fetchContent slug issueKey =
+  ElmFire.once
+    ( ElmFire.valueChanged ElmFire.noOrder )
+    ( ElmFire.fromUrl Config.firebaseUrl
+        |> ElmFire.sub "content"
+        |> ElmFire.sub slug
+        |> ElmFire.sub issueKey
+    )
+    |> Task.toResult
+    |> Task.map QueryContentResult
+    |> Effects.task
+
+
+view : Address Action -> Model -> Html
+view =
+  HL.lazy2 viewThunk
+
+viewThunk : Address Action -> Model -> Html
+viewThunk address model =
   H.div
     [ HA.class "stage" ]
-    [ H.div [ HA.class "title" ] [ H.text issue.title ]
-    , H.div [ HA.class "slug" ] [ H.text slug ]
-    , case issue.teaser of
+    [ H.div [ HA.class "title" ] [ H.text model.issue.title ]
+    , H.div [ HA.class "slug" ] [ H.text model.slug ]
+    , case model.issue.teaser of
         Just teaser ->
           H.div
             [ HA.class "teaser"
@@ -61,4 +146,20 @@ viewThunk address context { slug, issue } =
           H.div
             [ HA.class "teaser missing" ]
             [ H.text "No teaser" ]
+    , case model.checkout of
+        Just checkout ->
+          Checkout.view
+            (forwardTo address CheckoutAction)
+            checkout
+        Nothing ->
+          H.text ""
+    , case model.content of
+        Just htmlString ->
+          H.div
+            [ HA.class "teaser"
+            , HA.property "innerHTML" <| JE.string htmlString
+            ]
+            []
+        Nothing ->
+          H.text ""
     ]

--- a/src/Store/Customer.elm
+++ b/src/Store/Customer.elm
@@ -1,0 +1,108 @@
+module Store.Customer
+  ( Model, init, Action, update
+  , getIssueKey
+  ) where
+
+import Dict exposing (Dict)
+import Signal exposing (Address, message, forwardTo)
+import Task exposing (Task, andThen)
+import Effects exposing (Effects, Never)
+import Json.Encode as JE
+import Json.Decode as JD exposing ((:=))
+
+import ElmFire
+import ElmFire.Dict
+
+import CommonTypes exposing (..)
+
+--------------------------------------------------------------------------------
+
+type alias Model =
+  { uid : UId
+  , email : String
+  -- , paymentData : PaymentData
+  , purchases : Purchases
+  }
+
+type alias PaymentData =
+  {
+  }
+
+type alias Purchases =
+  Dict Slug IssueKey
+
+--------------------------------------------------------------------------------
+
+syncConfigPurchases : ElmFire.Location -> ElmFire.Dict.Config IssueKey
+syncConfigPurchases location =
+  { location = location
+  , orderOptions = ElmFire.noOrder
+  , encoder = \key -> JE.string key
+  , decoder = JD.string
+  }
+
+--------------------------------------------------------------------------------
+
+init : Address Action -> ElmFire.Location -> UId -> (Model, Effects Action)
+init address location uid =
+  ( { uid = uid
+    , email = ""
+    , purchases = Dict.empty
+    }
+  , Effects.batch
+      [ ( ElmFire.once
+            (ElmFire.valueChanged ElmFire.noOrder)
+            (location |> ElmFire.sub uid |> ElmFire.sub "email")
+          |> Task.toResult
+          |> Task.map QueryStaticResult
+          |> Effects.task
+        )
+      , ( ElmFire.Dict.subscribeDelta
+            (forwardTo address DeltaPurchases)
+            ( syncConfigPurchases
+                (location |> ElmFire.sub uid |> ElmFire.sub "purchases")
+            )
+          |> Task.toResult
+          |> Task.map QueryPurchasesResult
+          |> Effects.task
+        )
+      ]
+  )
+
+type Action
+  = QueryStaticResult (Result ElmFire.Error ElmFire.Snapshot)
+  | QueryPurchasesResult (Result ElmFire.Error (Task ElmFire.Error ()))
+  | DeltaPurchases (ElmFire.Dict.Delta IssueKey)
+
+update : Action -> Model -> Model
+update action model =
+  case action of
+    QueryStaticResult (Err error) ->
+      always model <|
+        Debug.log "Firebase: customer query error" error
+
+    QueryStaticResult (Ok snapshot) ->
+      case JD.decodeValue JD.string snapshot.value of
+        Err error ->
+          always model <|
+            Debug.log "Firebase: customer email decoding error" error
+
+        Ok email ->
+          { model | email = email }
+
+    QueryPurchasesResult (Err error) ->
+      always model <|
+        Debug.log "Firebase: purchases query error" error
+
+    QueryPurchasesResult (Ok unsubscribeTask) ->
+      -- No need to execute the unsubscribeTask on sign-out.
+      -- After signing out Firebase will stop the subscription with an error,
+      -- which is silently ignored by ElmFire.Dict.
+      model
+
+    DeltaPurchases delta ->
+      { model | purchases = ElmFire.Dict.update delta model.purchases }
+
+getIssueKey : Slug -> Model -> Maybe IssueKey
+getIssueKey slug model =
+  Dict.get slug model.purchases

--- a/src/Store/Issues.elm
+++ b/src/Store/Issues.elm
@@ -10,8 +10,6 @@ import Effects exposing (Effects, Never)
 import Json.Encode as JE
 import Json.Decode as JD exposing ((:=))
 
-import Debug
-
 import ElmFire
 import ElmFire.Dict
 

--- a/src/Store/Shop.elm
+++ b/src/Store/Shop.elm
@@ -47,17 +47,15 @@ type Action
 update : Action -> Model -> Model
 update action model =
   case action of
-    QueryResult result ->
-      case result of
+    QueryResult (Err error) ->
+      always model <|
+        Debug.log "Firebase: shop query error" error
+
+    QueryResult (Ok snapshot) ->
+      case JD.decodeValue decoder snapshot.value of
         Err error ->
           always model <|
-            Debug.log "Firebase: shop query error" error
+            Debug.log "Firebase: shop decoding error" error
 
-        Ok snapshot ->
-          case JD.decodeValue decoder snapshot.value of
-            Err error ->
-              always model <|
-                Debug.log "Firebase: shop decoding error" error
-
-            Ok shop ->
-              shop
+        Ok shop ->
+          shop

--- a/src/demo.css
+++ b/src/demo.css
@@ -1,0 +1,21 @@
+
+.header, .catalog, .stage, .checkout {
+  padding: 4px;
+}
+
+.header {
+  border: solid 2px blue;
+}
+
+.catalog {
+  border: solid 2px orange;
+}
+
+.stage {
+  border: solid 2px green;
+}
+
+.checkout {
+  border: solid 2px red;
+}
+

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 require('./index.html');
+require('./demo.css');
+
 var Elm = require('./Main');
 
 Elm.embed (

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,10 @@ module.exports = {
       test: /\.elm$/,
       exclude: [/elm-stuff/, /node_modules/],
       loader: 'elm-webpack'
-    }],
+    }, { test: /\.(css)$/,
+        loader: 'style-loader!css-loader'
+    }
+    ],
 
     noParse: /\.elm$/
   },


### PR DESCRIPTION
* New Component.Checkout.elm  
    * Planned for sign-in, sign-up, pw-reset, buy
    * Currently only the sign-in functionality implemented
    * Form validation currently only performed after blurring the fields
        * This will change when package  [etaque/elm-simple-form](https://github.com/etaque/elm-simple-form) resolves [this](https://github.com/etaque/elm-simple-form/issues/11) issue
    * Sign-in works (user logins are to be handled in Firease's Dashboard)
* Header
    * Reflect sign-in state, show email address
    * Perform sign-out
* Page.elm
    * After sign-in creates a Store.Customer
* New Customer.elm
    * Queries customer's email
    * Subscribe to customer's purchases
    * Updates in purchases are handled in a reactive manner
* Stage.elm
    * Load and show paid content if customer signed in and purchased the current issue
* Some test CSS to frame components
* Deposit Firebase security rules in docs/