### PR TITLE
Show purchases. Scroll on sign-in

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -13,7 +13,7 @@
         "elm-community/elm-history": "1.0.1 <= v < 2.0.0",
         "elm-lang/core": "3.0.0 <= v < 4.0.0",
         "etaque/elm-route-parser": "2.2.0 <= v < 3.0.0",
-        "etaque/elm-simple-form": "1.0.2 <= v < 2.0.0",
+        "etaque/elm-simple-form": "2.0.1 <= v < 3.0.0",
         "evancz/elm-effects": "2.0.1 <= v < 3.0.0",
         "evancz/elm-html": "4.0.2 <= v < 5.0.0",
         "evancz/elm-http": "3.0.0 <= v < 4.0.0",

--- a/src/Components/Catalog.elm
+++ b/src/Components/Catalog.elm
@@ -88,7 +88,9 @@ view address context model =
   H.div
     [ HA.class "catalog" ]
     [ H.ul
-        []
+      [ HA.classList
+          [ ("signed-in", context.customer /= Nothing) ]
+      ]
         ( List.map (viewIssue address context) model.visible )
     , H.button
         [ HA.disabled (model.position <= 0)

--- a/src/Components/Catalog.elm
+++ b/src/Components/Catalog.elm
@@ -3,12 +3,13 @@ module Components.Catalog
   , setSize, setIssues
   ) where
 
+import Dict exposing (Dict)
 import Signal exposing (Address, forwardTo)
 import Html as H exposing (Html)
 import Html.Attributes as HA
 import Html.Events as HE
 
-import CommonTypes exposing (Slug)
+import Types exposing (Slug)
 import Store.Issues as Issues exposing (Issue)
 import Store.Customer as Customer
 import Route exposing (Route)
@@ -105,11 +106,19 @@ viewIssue : Address Action -> Context a -> (Slug, Issue) -> Html
 viewIssue address context (slug, issue) =
   let
     isCurrentRoute = context.route == Route.Issue slug
+    paid =
+      case context.customer of
+        Just { purchases } ->
+          Just (Dict.member slug purchases)
+        Nothing ->
+          Nothing
   in
     H.li
       [ HA.classList
           [ ("item", True)
           , ("selected", isCurrentRoute)
+          , ("paid", paid == Just True)
+          , ("unpaid", paid == Just False)
           ]
       ]
       [ H.button

--- a/src/Components/Checkout.elm
+++ b/src/Components/Checkout.elm
@@ -13,12 +13,12 @@ import ElmFire
 import ElmFire.Auth
 
 import Form exposing (Form)
-import Form.Validate exposing (Validation, (:=))
+import Form.Validate exposing (Validation)
 import Form.Field exposing (Field)
 import Form.Input
 
 import Config
-import CommonTypes exposing (Slug)
+import Types exposing (Slug)
 import Store.Customer as Customer
 
 
@@ -35,19 +35,18 @@ type alias SignInData =
 validateSignIn : Validation () SignInData
 validateSignIn =
   Form.Validate.form2 SignInData
-    ("email" := Form.Validate.email)
-    ("password" := Form.Validate.string)
+    (Form.Validate.get "email" Form.Validate.email)
+    (Form.Validate.get "password" Form.Validate.string)
 
 
 init : Model
 init =
   { signInForm =
       Form.initial
-        [ ("email", Form.Field.text "")
-        , ("password", Form.Field.text "")
+        [ ("email", Form.Field.Text "")
+        , ("password", Form.Field.Text "")
         ]
         validateSignIn
-      |> Form.update Form.validate
   }
 
 
@@ -108,17 +107,20 @@ view address model =
     valid = Form.getErrors form |> List.isEmpty
   in
   H.div
-    [ HA.class "checkout" ]
+    [ HA.class "checkout"
+    , HA.id "checkout"
+    ]
     [ H.div
         [ HA.class "login" ]
         [ H.form
-            [ HA.name "login" -- TODO: necessary?
+            [ HA.name "login"
             ]
             [ Form.Input.textInput
                 emailState
                 formAddress
                 [ HA.class "email"
                 , HA.placeholder "email"
+                , HA.id "email"
                 ]
             , errorFor emailState
             , Form.Input.textInput

--- a/src/Components/Header.elm
+++ b/src/Components/Header.elm
@@ -30,7 +30,8 @@ update action model =
 
 type alias Context a =
   { a
-  | setRouteAddress : Address Route
+  | focusSignInAddress : Address ()
+  , setRouteAddress : Address Route
   , signOutAddress : Address ()
   , route : Route
   , customer : Maybe Customer.Model
@@ -66,8 +67,7 @@ view address context model =
                 [ H.text "Sign-out" ]
             Nothing ->
               H.button
-                [ -- TODO: Scroll down to sign-in-form
-                  -- HE.onClick context.setRouteAddress Route.All
+                [ HE.onClick context.focusSignInAddress ()
                 ]
                 [ H.text "Sign-in" ]
         ]

--- a/src/Components/Page.elm
+++ b/src/Components/Page.elm
@@ -13,7 +13,7 @@ import Html.Attributes as HA
 import ElmFire
 import ElmFire.Auth
 
-import CommonTypes exposing (Slug)
+import Types exposing (Slug)
 import Config
 import Route exposing (Route)
 import Store.Shop as Shop
@@ -175,11 +175,17 @@ update action model =
       in
         ( model, Effects.none )
 
-view : Address Action -> Model -> Html
-view address model =
+type alias Context a =
+  { a
+  | focusSignInAddress : Address ()
+  }
+
+view : Address Action -> Context a -> Model -> Html
+view address context model =
   let
-    context =
-      { setRouteAddress = forwardTo address SetRoute
+    subContext =
+      { focusSignInAddress = context.focusSignInAddress
+      , setRouteAddress = forwardTo address SetRoute
       , signOutAddress = forwardTo address SignOut
       , route = model.route
       , customer = model.customer
@@ -189,11 +195,11 @@ view address model =
       []
       [ Header.view
           (forwardTo address HeaderAction)
-          context
+          subContext
           model.header
       , Catalog.view
           (forwardTo address CatalogAction)
-          context
+          subContext
           model.catalog
       , case model.body of
           Stage stage ->

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -64,6 +64,16 @@ main =
 
 --------------------------------------------------------------------------------
 
+-- Use auxiliary JS code to set the focus to sign-in email field
+
+focusSignIn : Mailbox ()
+focusSignIn = mailbox ()
+
+port runFocusSignIn : Signal ()
+port runFocusSignIn = focusSignIn.signal
+
+--------------------------------------------------------------------------------
+
 
 type alias Model =
   { shop : Shop.Model
@@ -187,5 +197,6 @@ view address model =
     []
     [ Page.view
         (forwardTo address PageAction)
+        { focusSignInAddress = focusSignIn.address }
         model.page
     ]

--- a/src/Store/Content.elm
+++ b/src/Store/Content.elm
@@ -1,0 +1,53 @@
+module Store.Content (Model, init, Action, update) where
+
+import Task exposing (Task, andThen)
+import Effects exposing (Effects, Never)
+import Json.Decode as JD exposing ((:=))
+import ElmFire
+
+import Types exposing (..)
+
+--------------------------------------------------------------------------------
+
+
+type alias Model = Maybe String
+
+
+decoder : JD.Decoder String
+decoder = ("body" := JD.string)
+
+
+--------------------------------------------------------------------------------
+
+
+init : ElmFire.Location -> Slug -> IssueKey -> ( Model, Effects Action )
+init location slug issueKey =
+  ( Nothing
+  , ElmFire.once
+      ( ElmFire.valueChanged ElmFire.noOrder )
+      ( location |> ElmFire.sub slug |> ElmFire.sub issueKey )
+      |> Task.toResult
+      |> Task.map QueryResult
+      |> Effects.task
+  )
+
+
+type Action
+  = QueryResult (Result ElmFire.Error ElmFire.Snapshot)
+
+
+update : Action -> Model -> Model
+update action model =
+  case action of
+    QueryResult (Err error) ->
+      always Nothing <|
+        Debug.log "Firebase: content query error" error
+
+    QueryResult (Ok snapshot) ->
+      case JD.decodeValue decoder snapshot.value of
+        Err error ->
+          always Nothing <|
+            Debug.log "Firebase: shop decoding error" error
+
+        Ok body ->
+          Just body

--- a/src/Store/Customer.elm
+++ b/src/Store/Customer.elm
@@ -13,7 +13,7 @@ import Json.Decode as JD exposing ((:=))
 import ElmFire
 import ElmFire.Dict
 
-import CommonTypes exposing (..)
+import Types exposing (..)
 
 --------------------------------------------------------------------------------
 

--- a/src/Store/Issues.elm
+++ b/src/Store/Issues.elm
@@ -13,7 +13,7 @@ import Json.Decode as JD exposing ((:=))
 import ElmFire
 import ElmFire.Dict
 
-import CommonTypes exposing (Slug)
+import Types exposing (Slug)
 
 --------------------------------------------------------------------------------
 

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -1,4 +1,4 @@
-module CommonTypes (..) where
+module Types (..) where
 
 
 type alias Slug = String

--- a/src/demo.css
+++ b/src/demo.css
@@ -15,7 +15,22 @@
   border: solid 2px green;
 }
 
+.content {
+  border: solid 2px lightgreen;
+}
+
 .checkout {
   border: solid 2px red;
 }
 
+.catalog .paid::after {
+  content: " cleared"
+}
+
+.catalog .unpaid::after {
+  content: " locked"
+}
+
+.content.fetching::after {
+  content: "(fetching content)"
+}

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,18 @@ require('./demo.css');
 
 var Elm = require('./Main');
 
-Elm.embed (
+var main = Elm.embed (
   Elm.Main,
   document.getElementById('main'),
   { initialPath: window.location.pathname }
 );
+
+// Auxiliary JS code to set the focus to an input field
+main.ports.runFocusSignIn.subscribe (function () {
+  var email = document.querySelectorAll ("#email");
+    if (email.length === 1 && document.activeElement !== email[0])
+      email[0].focus ();
+  var checkout = document.querySelectorAll ("#checkout");
+    if (checkout.length === 1 && document.activeElement !== checkout[0])
+      checkout[0].scrollIntoView (false);
+});


### PR DESCRIPTION
* Form validation executed immediately
    * by updating dependency `etaque/elm-simple-form` to verion 2.0.1
* Catalog.elm
    * Show purchase state of items when signed-in
    * List gets class `signed-in`, items either class `paid` or `unpaid`
* New Store/Content.elm
    * Query one issue content from Firebase
    * Code was embedded in Stage.elm
* Header.elm
    * Sign-in button now scrolls to and focuses the email field of Checkout
    * Uses an outbound port to execute the DOM functions from JavaScript
 