### PR TITLE
Change Firebase schema for permissions to read payed content

### DIFF
--- a/docs/fb-rules.json
+++ b/docs/fb-rules.json
@@ -12,11 +12,14 @@
         ".write": "$user == auth.uid"
       }
     },
+    "permissions": {
+      "$user": {
+        ".read":  "$user == auth.uid"
+      }
+    },
     "content": {
       "$slug": {
-        "$key": {
-          ".read":  "root.child('customers').child(auth.uid).child('purchases').child($slug).val() == $key"
-        }
+        ".read":  "root.child('permissions').child(auth.uid).child($slug).child('valid').exists()"
       }
     }
   }

--- a/src/Components/Catalog.elm
+++ b/src/Components/Catalog.elm
@@ -110,17 +110,17 @@ viewIssue address context (slug, issue) =
     isCurrentRoute = context.route == Route.Issue slug
     paid =
       case context.customer of
-        Just { purchases } ->
-          Just (Dict.member slug purchases)
+        Just customer ->
+          Customer.getIssuePermission slug customer
         Nothing ->
-          Nothing
+          False
   in
     H.li
       [ HA.classList
           [ ("item", True)
           , ("selected", isCurrentRoute)
-          , ("paid", paid == Just True)
-          , ("unpaid", paid == Just False)
+          , ("paid", paid)
+          , ("unpaid", not paid)
           ]
       ]
       [ H.button

--- a/src/Components/Checkout.elm
+++ b/src/Components/Checkout.elm
@@ -168,7 +168,6 @@ type Action
   | Done
   -- Only for testing purposes
   | TestCardData
-  | SimulatePurchase UId Slug
 
 
 type alias UpdateContext =
@@ -281,21 +280,6 @@ update context action model =
           |> F.update ( F.Input "card.cvc.value" <| FF.Text "123" )
         }
       , Effects.none
-      )
-
-    SimulatePurchase uid slug ->
-      ( model
-      , ElmFire.set
-          ( JE.string "theSecretKey" )
-          ( (ElmFire.fromUrl Config.firebaseUrl)
-            |> ElmFire.sub "customers"
-            |> ElmFire.sub uid
-            |> ElmFire.sub "purchases"
-            |> ElmFire.sub slug
-          )
-        |> Task.toResult
-        |> Task.map (always NoOp)
-        |> Effects.task
       )
 
 
@@ -464,33 +448,21 @@ view address context model =
           [ ( True -- TODO: Show selectInput for debugging only
             , H.div
                 [ HA.class "debug" ]
-                (
-                  [ FI.selectInput
-                    [ ("signIn", "intent: signIn")
-                      , ("signUp", "intent: signUp")
-                      , ("signUpAndBuy", "intent: signUpAndBuy")
-                      , ("newCardBuy", "intent: newCardBuy")
-                      , ("existingCardBuy", "intent: existingCardBuy")
-                      , ("resetPw", "intent: resetPw")
-                      ]
-                      intentState
-                      formAddress
-                      []
-                  , H.button
-                      [ HE.onClick address TestCardData ]
-                      [ H.text "Use test card data" ]
-                  ]
-                  ++
-                  ( case context.customer of
-                      Just customer ->
-                        [ H.button
-                            [ HE.onClick address (SimulatePurchase customer.uid context.slug) ]
-                            [ H.text "Simulate purchase" ]
-                        ]
-                      Nothing ->
-                        []
-                  )
-                )
+                [ FI.selectInput
+                  [ ("signIn", "intent: signIn")
+                    , ("signUp", "intent: signUp")
+                    , ("signUpAndBuy", "intent: signUpAndBuy")
+                    , ("newCardBuy", "intent: newCardBuy")
+                    , ("existingCardBuy", "intent: existingCardBuy")
+                    , ("resetPw", "intent: resetPw")
+                    ]
+                    intentState
+                    formAddress
+                    []
+                , H.button
+                    [ HE.onClick address TestCardData ]
+                    [ H.text "Use test card data" ]
+                ]
             )
           , ( model.errorMsg /= Nothing
             , H.div

--- a/src/Components/Page.elm
+++ b/src/Components/Page.elm
@@ -166,9 +166,7 @@ update context action model =
         ( customerModel, customerEffects ) =
           Customer.init
             ( forwardTo model.address CustomerAction )
-            ( ElmFire.fromUrl Config.firebaseUrl
-               |> ElmFire.sub "customers"
-            )
+            ( ElmFire.fromUrl Config.firebaseUrl )
             authentication.uid
       in
         ( { model | customer = Just customerModel }

--- a/src/Components/Stage.elm
+++ b/src/Components/Stage.elm
@@ -92,8 +92,8 @@ customerChanged maybeCustomer model =
     ( model1, effects1 ) =
       case maybeCustomer of
         Just customer ->
-          case Customer.getIssueKey model.slug customer of
-            Just issueKey ->
+          if Customer.getIssuePermission model.slug customer
+            then
               case model.content of
                 Just content ->
                   ( model, Effects.none )
@@ -103,7 +103,6 @@ customerChanged maybeCustomer model =
                       Content.init
                         ( ElmFire.fromUrl Config.firebaseUrl |> ElmFire.sub "content" )
                         model.slug
-                        issueKey
                   in
                     ( { model
                       | content = Just contentModel
@@ -111,7 +110,7 @@ customerChanged maybeCustomer model =
                       }
                     , Effects.map ContentAction contentEffects
                     )
-            Nothing ->
+            else
               ( addCheckout { model | content = Nothing }
               , Effects.none
               )

--- a/src/Store/Content.elm
+++ b/src/Store/Content.elm
@@ -20,12 +20,12 @@ decoder = ("body" := JD.string)
 --------------------------------------------------------------------------------
 
 
-init : ElmFire.Location -> Slug -> IssueKey -> ( Model, Effects Action )
-init location slug issueKey =
+init : ElmFire.Location -> Slug -> ( Model, Effects Action )
+init location slug =
   ( Nothing
   , ElmFire.once
       ( ElmFire.valueChanged ElmFire.noOrder )
-      ( location |> ElmFire.sub slug |> ElmFire.sub issueKey )
+      ( location |> ElmFire.sub slug )
       |> Task.toResult
       |> Task.map QueryResult
       |> Effects.task

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -3,7 +3,6 @@ module Types (..) where
 
 type alias Slug = String
 type alias UId = String
-type alias IssueKey = String
 
 type alias StripeRequest =
   { request: String


### PR DESCRIPTION
Old schema uses a secret string to lock paid content.

Better way: Use a separate branch `permissions` that guides the security rules.